### PR TITLE
format the match duration as h:mm

### DIFF
--- a/src/main/java/com/eg/aoe2slackbot/view/SlackMatchResult.java
+++ b/src/main/java/com/eg/aoe2slackbot/view/SlackMatchResult.java
@@ -32,8 +32,6 @@ public class SlackMatchResult {
 
         List<LayoutBlock> messageList = new ArrayList<>();
 
-        NumberFormat formatter = new DecimalFormat("#0.00");
-
         SectionBlock titleBlock = SectionBlock
                 .builder()
                 .text(MarkdownTextObject
@@ -45,7 +43,7 @@ public class SlackMatchResult {
                                         RefDataService.aoe2RefData.getMapTypeMap().get(matchResult.getMatch().getMapType()) +
                                 "* of size " + RefDataService.aoe2RefData.getMapSizeMap().get(matchResult.getMatch().getMapSize()) +
                                 ".  \nThe match concluded at " + DateTimeFormatter.RFC_1123_DATE_TIME.format(matchResult.getMatch().getFinishedDate()) +
-                                " after lasting " + formatter.format((double) matchDuration.toMinutes() / 60.0) + " Hours")
+                                " after lasting " + durationAsString(matchDuration))
                         .build())
                 .build();
 
@@ -110,6 +108,13 @@ public class SlackMatchResult {
 
         return "<https://aoe2.net/#profile-" + steamId + "|" + name + ">";
 
+    }
+
+    // package private for accessibility in tests
+    static String durationAsString(Duration duration) {
+        long hours = duration.toHours();
+        long minutes = duration.toMinutes();
+        return hours + ":" + String.format("%02d", minutes - 60 * hours);
     }
 
 

--- a/src/test/java/com/eg/aoe2slackbot/view/SlackMatchResultTests.java
+++ b/src/test/java/com/eg/aoe2slackbot/view/SlackMatchResultTests.java
@@ -1,0 +1,55 @@
+package com.eg.aoe2slackbot.view;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+
+import static com.eg.aoe2slackbot.view.SlackMatchResult.durationAsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class SlackMatchResultTests {
+
+    @Test
+    void durationAsStringTest73() {
+        String expected = "1:13";
+        String actual = durationAsString(Duration.ofMinutes(73));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void durationAsStringTest0() {
+        String expected = "0:00";
+        String actual = durationAsString(Duration.ofMinutes(0));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void durationAsStringTest7() {
+        String expected = "0:07";
+        String actual = durationAsString(Duration.ofMinutes(7));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void durationAsStringTest37() {
+        String expected = "0:37";
+        String actual = durationAsString(Duration.ofMinutes(37));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void durationAsStringTest483() {
+        String expected = "8:03";
+        String actual = durationAsString(Duration.ofMinutes(483));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void durationAsStringTest9117() {
+        String expected = "151:57";
+        String actual = durationAsString(Duration.ofMinutes(9117));
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Hey @tkelley-eg,

Take a look at this. I'm not sure how you are working in this informal project so I just pointed this branch at develop.

I thought it would be nice to have the duration formatted as h:mm instead of a decimal number of hours.

Side note: It took me much more time than the coding time to figure out how to get maven to do its thing and sync the dependencies.  :)  In Android development, I've only used gradle.  Googling was turning up no relevant answers.  I eventually figured out I had to go in and enable the bundled maven plugin in IDEA.  Several invalidate cache and restarts later, it finally was happy with everything. 